### PR TITLE
Editing typeaheadInput component template to add support for Safari

### DIFF
--- a/vue-typeahead.js
+++ b/vue-typeahead.js
@@ -36,15 +36,7 @@ Vue.component('typeahead', {
   components: {
     typeaheadInput: {
       inherit: true,
-      template: `<input type="text"
-                        autocomplete="off"
-                        v-model="query"
-                        v-on="keydown: down|key 'down',
-                              keydown: up|key 'up',
-                              keydown: hit|key 'enter',
-                              keydown: reset|key 'esc',
-                              blur: reset,
-                              input: update"/>`
+      template: "<input type=\"text\" autocomplete=\"off\" v-model=\"query\" v-on=\"keydown: down|key 'down', keydown: up|key 'up', keydown: hit|key 'enter', keydown: reset|key 'esc', blur: reset, input: update\"/>"
     }
   },
 


### PR DESCRIPTION
Safari desktop v8.0.8 throws an error when back-ticks are used with the template string. Using double-quotes and escaping the attribute double quotes with back-slashes fixes this issue.
