### PR TITLE
Use secure resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="description" content="Typeahead component for Vue.js.">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400|Dosis:300">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400|Dosis:300">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="css/vue-theme.css">
     <link rel="stylesheet" href="css/typeahead.css">
@@ -22,7 +22,7 @@
             <iframe src="https://ghbtns.com/github-btn.html?user=pespantelis&repo=vue-typeahead&type=star&count=true" frameborder="0" scrolling="0" width="78px" height="20px"></iframe>
         </div>
 
-        <typeahead src="http://typeahead-js-twitter-api-proxy.herokuapp.com/demo/search" on-hit="{{goToProfile}}" limit="5" inline-template>
+        <typeahead src="https://typeahead-js-twitter-api-proxy.herokuapp.com/demo/search" on-hit="{{goToProfile}}" limit="5" inline-template>
             <div id="typeahead">
                 <i class="fa fa-search" v-show="isEmpty"></i>
                 <i class="fa fa-times" v-show="isDirty" v-on="click: reset"></i>
@@ -40,6 +40,6 @@
     </div>
 
     <script src="build/build.js"></script>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^https:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 </body>
 </html>


### PR DESCRIPTION
The demo was broken when you accessed it through [https](https://pespantelis.github.io/vue-typeahead/) 

This replaces the http:// locations with https so there are no more mixed content warnings or problems.
