### PR TITLE
Added support for browserify when using as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "vue": "^1.0.12",
     "vue-resource": "^0.5.1"
+  },
+  "browserify": {
+    "transform": [["babelify", { "presets": ["es2015"] }]]
   }
 }


### PR DESCRIPTION
Browserify 7 will throw an error when importing this module as it won't transform es6. Updated package.json to tell browserify to transform from es6.
