### PR TITLE
Added babelify browserify transform info to module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
+  },
+  "browserify": {
+    "transform": [["babelify", { "presets": ["es2015"] }]]
   }
 }


### PR DESCRIPTION
Using vueify and vue-typeahead in a project and found that the distribution JS was being included as-is (and then causing errors in the uglification). 

Following the babelify advice here fixed it:
https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed

Do you know of a better way to do this?
