### PR TITLE
Properly pass parameters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -69,7 +69,7 @@ export default {
         ? Object.assign({ [this.queryParamName]: this.query }, this.data)
         : this.data
 
-      return this.$http.get(src, params)
+      return this.$http.get(src, {params: params});
     },
 
     reset () {


### PR DESCRIPTION
WE should use second parameter as object with 'params' key
See https://github.com/vuejs/vue-resource/blob/master/docs/http.md
