### PR TITLE
Append slash only if the queryParamName is not defined

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ export default {
         return util.warn('You need to set the `src` property', this)
       }
 
-      if (this.queryParamName && this.src.substr(-1) !== '/') {
+      if (!this.queryParamName && this.src.substr(-1) !== '/') {
         this.src += '/'
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,7 @@ export default {
         return util.warn('You need to set the `src` property', this)
       }
 
-      if (this.src.substr(-1) !== '/') {
+      if (this.queryParamName && this.src.substr(-1) !== '/') {
         this.src += '/'
       }
 


### PR DESCRIPTION
Seems that we should append slash in the case when query is not used as GET parameter
