### PR TITLE
Fix #23 - Query parameter not sent

### DIFF
--- a/dist/vue-typeahead.common.js
+++ b/dist/vue-typeahead.common.js
@@ -81,7 +81,9 @@ exports.default = {
 
       var params = this.queryParamName ? (0, _assign2.default)((0, _defineProperty3.default)({}, this.queryParamName, this.query), this.data) : this.data;
 
-      return this.$http.get(src, params);
+      var options = { params: params };
+
+      return this.$http.get(src, options);
     },
     reset: function reset() {
       this.items = [];

--- a/src/main.js
+++ b/src/main.js
@@ -69,7 +69,11 @@ export default {
         ? Object.assign({ [this.queryParamName]: this.query }, this.data)
         : this.data
 
-      return this.$http.get(src, params)
+      const options = {
+        params: params
+      }
+
+      return this.$http.get(src, options)
     },
 
     reset () {


### PR DESCRIPTION
After vue-resource update the query parameter was not sent.

This is a simple fix.
