### PR TITLE
Support for "auto select" first item

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ export default {
       // (optional)
       minChars: 3,
 
+      // If to auto select the first item in the list
+      // (optional)
+      selectFirst: false,
+      
       // Override the default value (`q`) of query parameter name
       // Use a falsy value for RESTful query
       // (optional)

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,8 @@ export default {
       query: '',
       current: -1,
       loading: false,
-      queryParamName: 'q'
+      selectFirst: false,
+      queryParamName: 'q',
     }
   },
 
@@ -44,6 +45,10 @@ export default {
           this.items = this.limit ? data.slice(0, this.limit) : data
           this.current = -1
           this.loading = false
+
+          if (this.selectFirst && this.items.length >= 1) {
+            this.down()
+          }
         }
       })
     },


### PR DESCRIPTION
Handy when you often just want to hit the first item in the list after the search (so you don't have to hit the "down" key first if the first item is the one you want).

I noticed that the branch name is unfortunate ("option" should be "item"), hopefully that doesn't really matter.
