### PR TITLE
make sure items match the last query

### DIFF
--- a/dist/vue-typeahead.common.js
+++ b/dist/vue-typeahead.common.js
@@ -45,7 +45,7 @@ exports.default = {
 
   methods: {
     update: function update() {
-      var _this2 = this;
+      var _this = this;
 
       if (!this.query) {
         return this.reset();
@@ -59,9 +59,9 @@ exports.default = {
       this.query_count++;
 
       this.fetch().then(function (response) {
-        if (_this2.query) {
+        if (_this.query) {
           var data = response.data;
-          data = _this2.prepareResponseData ? _this2.prepareResponseData(data) : data;
+          data = _this.prepareResponseData ? _this.prepareResponseData(data) : data;
           var to_replace = _this.src;
           if (_this.queryParamName) {
             to_replace += '?' + _this.queryParamName + '=';
@@ -76,8 +76,8 @@ exports.default = {
             _this.items = _this.limit ? data.slice(0, _this.limit) : data;
           }
 
-          if (_this2.selectFirst) {
-            _this2.down();
+          if (_this.selectFirst) {
+            _this.down();
           }
         }
       });

--- a/src/main.js
+++ b/src/main.js
@@ -45,18 +45,18 @@ export default {
         if (this.query) {
           let data = response.data
           data = this.prepareResponseData ? this.prepareResponseData(data) : data
-          let to_replace = _this.src
-          if (_this.queryParamName) {
-            to_replace += '?' + _this.queryParamName + '='
+          let to_replace = this.src
+          if (this.queryParamName) {
+            to_replace += '?' + this.queryParamName + '='
           }
           let search_string = decodeURIComponent(response.url.replace(to_replace, '').replace(/\+/g, '%20'))
-          _this.query_results[search_string] = data
-          _this.query_count--
-          _this.current = -1
-          _this.loading = false
-          if (_this.query_count <= 0) {
-            data = _this.query_results[_this.query]
-            _this.items = _this.limit ? data.slice(0, _this.limit) : data
+          this.query_results[search_string] = data
+          this.query_count--
+          this.current = -1
+          this.loading = false
+          if (this.query_count <= 0) {
+            data = this.query_results[this.query]
+            this.items = this.limit ? data.slice(0, this.limit) : data
           }
 
           if (this.selectFirst) {

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,8 @@ export default {
       query: '',
       current: -1,
       loading: false,
+      query_count: 0,
+      query_results: {},
       selectFirst: false,
       queryParamName: 'q'
     }
@@ -37,14 +39,25 @@ export default {
       }
 
       this.loading = true
+      this.query_count++
 
       this.fetch().then((response) => {
         if (this.query) {
           let data = response.data
           data = this.prepareResponseData ? this.prepareResponseData(data) : data
-          this.items = this.limit ? data.slice(0, this.limit) : data
-          this.current = -1
-          this.loading = false
+          let to_replace = _this.src
+          if (_this.queryParamName) {
+            to_replace += '?' + _this.queryParamName + '='
+          }
+          let search_string = decodeURIComponent(response.url.replace(to_replace, '').replace(/\+/g, '%20'))
+          _this.query_results[search_string] = data
+          _this.query_count--
+          _this.current = -1
+          _this.loading = false
+          if (_this.query_count <= 0) {
+            data = _this.query_results[_this.query]
+            _this.items = _this.limit ? data.slice(0, _this.limit) : data
+          }
 
           if (this.selectFirst) {
             this.down()
@@ -75,6 +88,8 @@ export default {
 
     reset () {
       this.items = []
+      this.query_results = {}
+      this.query_count = 0
       this.query = ''
       this.loading = false
     },


### PR DESCRIPTION
Last sent query might not always be the last one to complete, in which case typeahead will display `items` that do not correspond to `this.query`
This patch ensures we wait until all queries are performed and then grab results matching `this.query`

References issue #46 