### PR TITLE
Reset current selection when items are reset

### DIFF
--- a/dist/vue-typeahead.common.js
+++ b/dist/vue-typeahead.common.js
@@ -100,6 +100,7 @@ exports.default = {
     cancel: function cancel() {},
     reset: function reset() {
       this.items = [];
+      this.current = -1;
       this.query = '';
       this.loading = false;
     },

--- a/src/main.js
+++ b/src/main.js
@@ -84,6 +84,7 @@ export default {
 
     reset () {
       this.items = []
+      this.current = -1
       this.query = ''
       this.loading = false
     },


### PR DESCRIPTION
I'm currently using this component in a pseudo-form that allows the user to submit the form if the input field receives an enter (not the autocomplete popup). I'm doing this by implementing a processEnter method based off of the onHit method:

```js
    processEnter() {
      if (this.current !== -1) {
        this.onHit(this.items[this.current]);
      } else {
        this.$emit('pressed:enter');
      }
    }
```

Currently, onHit will be called instead of emitting the enter press event after a reset(). This commit fixes that behavior.