### PR TITLE
Add an error handler to fetch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,11 @@ export default {
             this.down()
           }
         }
+      }).catch((error) => {
+        if (this.handleError) {
+          this.handleError(error)
+        }
+        this.loading = false
       })
     },
 


### PR DESCRIPTION
Fetch could fail and it would appear to be "loading" forever.

The handler will call a hook function (`handleError()`) if it is defined. It's a lot like like how `prepareResponseData()` gets called.