### PR TITLE
Add error handling cabability on fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ export default {
 **Escape:** Hide the list.
 
 ## States
+**error:** Indicates if an error what thrown and what it was when fetching data.
+
 **loading:** Indicates that awaits the data.
 
 **isEmpty:** Indicates that the input is empty.

--- a/dist/vue-typeahead.common.js
+++ b/dist/vue-typeahead.common.js
@@ -23,6 +23,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.default = {
   data: function data() {
     return {
+      error: null,
       items: [],
       query: '',
       current: -1,
@@ -59,6 +60,7 @@ exports.default = {
         return;
       }
 
+      this.error = null;
       this.loading = true;
 
       this.fetch().then(function (response) {
@@ -73,6 +75,8 @@ exports.default = {
             _this.down();
           }
         }
+      }).catch(function (err) {
+        _this.error = err;
       });
     },
     fetch: function fetch() {
@@ -99,6 +103,7 @@ exports.default = {
     },
     cancel: function cancel() {},
     reset: function reset() {
+      this.error = null;
       this.items = [];
       this.query = '';
       this.loading = false;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { util } from 'vue'
 export default {
   data () {
     return {
+      error: null,
       items: [],
       query: '',
       current: -1,
@@ -38,9 +39,10 @@ export default {
         return
       }
 
+      this.error = null
       this.loading = true
 
-      this.fetch().then((response) => {
+      this.fetch().then(response => {
         if (response && this.query) {
           let data = response.data
           data = this.prepareResponseData ? this.prepareResponseData(data) : data
@@ -52,6 +54,8 @@ export default {
             this.down()
           }
         }
+      }).catch(err => {
+        this.error = err
       })
     },
 
@@ -83,6 +87,7 @@ export default {
     },
 
     reset () {
+      this.error = null
       this.items = []
       this.query = ''
       this.loading = false


### PR DESCRIPTION
Adds a new `error` property/state to be set if the `fetch()` promise fails due to backend request failure or the backend responds with something >=400 (if your HTTP client throws an error in this case).