### PR TITLE
Add isReady option

### DIFF
--- a/dist/vue-typeahead.common.js
+++ b/dist/vue-typeahead.common.js
@@ -28,7 +28,8 @@ exports.default = {
       current: -1,
       loading: false,
       selectFirst: false,
-      queryParamName: 'q'
+      queryParamName: 'q',
+      isReady: false
     };
   },
 
@@ -50,6 +51,10 @@ exports.default = {
       var _this = this;
 
       this.cancel();
+
+      if (this.isReady) {
+        return;
+      }
 
       if (!this.query) {
         return this.reset();
@@ -91,7 +96,8 @@ exports.default = {
       var params = this.queryParamName ? (0, _assign2.default)((0, _defineProperty3.default)({}, this.queryParamName, this.query), this.data) : this.data;
 
       var cancel = new _promise2.default(function (resolve) {
-        return _this2.cancel = resolve;
+        _this2.cancel = resolve;
+        return _this2.cancel;
       });
       var request = this.$http.get(src, { params: params });
 

--- a/src/main.js
+++ b/src/main.js
@@ -77,8 +77,11 @@ export default {
         ? Object.assign({ [this.queryParamName]: this.query }, this.data)
         : this.data
 
-      let cancel = new Promise((resolve) => this.cancel = resolve)
-      let request = this.$http.get(src, { params })
+      const cancel = new Promise((resolve) => {
+        this.cancel = resolve
+        return this.cancel
+      })
+      const request = this.$http.get(src, { params })
 
       return Promise.race([cancel, request])
     },

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,8 @@ export default {
       current: -1,
       loading: false,
       selectFirst: false,
-      queryParamName: 'q'
+      queryParamName: 'q',
+      isReady: false
     }
   },
 
@@ -29,6 +30,10 @@ export default {
   methods: {
     update () {
       this.cancel()
+
+      if (this.isReady) {
+        return
+      }
 
       if (!this.query) {
         return this.reset()


### PR DESCRIPTION
I fix the problem that update method is executed when set props to query.
Following usage.
```
export default {
  extends: VueTypeahead,
  props: [
    'value'
  ],
  data: function () {
    return {
      src: '/my/sample/api',
    };
  },
  created: function () {
    this.isReady = true
    this.query = this.value;
    this.$watch('value', () => this.isReady = false);
  },
  methods: {
    hit: function (e) {
      // ~
    }
}
```
I found this problem when I tested it with IE11, but I could not find a function that cancels the request in vue-typeahead.
If I am completely missing the functionality to cancel the http request, my bad.

ref: https://github.com/pespantelis/vue-typeahead/issues/56