### PR TITLE
Allow a default resultset

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ export default {
       current: -1,
       loading: false,
       selectFirst: false,
-      queryParamName: 'q'
+      queryParamName: 'q',
     }
   },
 
@@ -30,7 +30,7 @@ export default {
     update () {
       this.cancel()
 
-      if (!this.query) {
+      if (!this.query && this.minChars > 0) {
         return this.reset()
       }
 
@@ -41,7 +41,7 @@ export default {
       this.loading = true
 
       this.fetch().then((response) => {
-        if (response && this.query) {
+        if (response && (this.query || this.minChars == 0)) {
           let data = response.data
           data = this.prepareResponseData ? this.prepareResponseData(data) : data
           this.items = this.limit ? data.slice(0, this.limit) : data


### PR DESCRIPTION
We had a use case where we wanted to display some results immediately after the control is selected by the user (ie: when @focus). So we added @focus="update" and adjusted the update() function as above. If minChars is 0, then the client may be expecting a default result set (like in our case). What do you think?
I wanted to avoid introducing new variables (something like allowDefault) so I just found a way with minChars == 0.